### PR TITLE
Generic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.pem
 *.cov
 jose-util/jose-util
+/.idea

--- a/cipher/cbc_hmac.go
+++ b/cipher/cbc_hmac.go
@@ -27,7 +27,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"hash"
-	"strings"
 )
 
 const (
@@ -40,8 +39,6 @@ var (
 	dot        = []byte(".")
 	zero       = []byte{0, 0, 0, 0}
 )
-
-const rsa2048ByteKeySize = 2048 / 8 // 256
 
 // ComputeIntegrityKey derives an integrity key based on a master key, using the A128CBC+HS256 draft specification
 func ComputeIntegrityKey(key []byte, algorithm string, hash hash.Hash) []byte {
@@ -322,23 +319,6 @@ func unpadBuffer(buffer []byte, blockSize int) ([]byte, error) {
 	return buffer[:len(buffer)-count], nil
 }
 
-const (
-	base64PadCharacter = "="
-
-	base64Character62 = "+"
-	base64Character63 = "/"
-
-	base64UrlCharacter62 = "-"
-	base64UrlCharacter63 = "_"
-)
-
-var replacer = strings.NewReplacer(base64Character62, base64UrlCharacter62, base64Character63, base64UrlCharacter63)
-
 func base64URLEncode(input []byte) string {
-	// encode as base64
-	encoded := base64.RawStdEncoding.EncodeToString(input)
-
-	encoded = replacer.Replace(encoded)
-
-	return encoded
+	return base64.RawURLEncoding.EncodeToString(input)
 }

--- a/cipher/cbc_hmac.go
+++ b/cipher/cbc_hmac.go
@@ -127,6 +127,7 @@ func NewCBCHMAC(key []byte, newBlockCipher func([]byte) (cipher.Block, error)) (
 		blockCipher:  blockCipher,
 		authtagBytes: keySize,
 		integrityKey: integrityKey,
+		isKdfCbc:     false,
 	}, nil
 }
 

--- a/crypter.go
+++ b/crypter.go
@@ -332,17 +332,11 @@ func (obj JsonWebEncryption) Decrypt(decryptionKey interface{}) ([]byte, error) 
 	var plaintext []byte
 	recipient := obj.recipients[0]
 	recipientHeaders := obj.mergedHeaders(&recipient)
+	parts.kdata = recipient.encryptedKey
 
 	cek, err := decrypter.decryptKey(recipientHeaders, &recipient, generator)
 	if err == nil {
 		// Found a valid CEK -- let's try to decrypt.
-
-		// if A128+HS256, we need to append additional data
-		if obj.protected.Enc == A128CBCpHS256 {
-			parts.kdata = make([]byte, len(recipient.encryptedKey))
-			copy(parts.kdata, recipient.encryptedKey)
-		}
-
 		plaintext, err = cipher.decrypt(cek, authData, parts)
 	}
 

--- a/shared.go
+++ b/shared.go
@@ -101,9 +101,11 @@ const (
 // Content encryption algorithms
 const (
 	A128CBC_HS256 = ContentEncryption("A128CBC-HS256") // AES-CBC + HMAC-SHA256 (128)
-	A128CBCpHS256 = ContentEncryption("A128CBC+HS256") // AES-CBC + HMAC-SHA256 (128)
 	A192CBC_HS384 = ContentEncryption("A192CBC-HS384") // AES-CBC + HMAC-SHA384 (192)
 	A256CBC_HS512 = ContentEncryption("A256CBC-HS512") // AES-CBC + HMAC-SHA512 (256)
+	A128CBCpHS256 = ContentEncryption("A128CBC+HS256") // AES-CBC + HMAC-SHA256 (128)
+	A192CBCpHS384 = ContentEncryption("A192CBC+HS384") // AES-CBC + HMAC-SHA384 (192)
+	A256CBCpHS512 = ContentEncryption("A256CBC+HS512") // AES-CBC + HMAC-SHA512 (256)
 	A128GCM       = ContentEncryption("A128GCM")       // AES-GCM (128)
 	A192GCM       = ContentEncryption("A192GCM")       // AES-GCM (192)
 	A256GCM       = ContentEncryption("A256GCM")       // AES-GCM (256)


### PR DESCRIPTION
 - we actually already chose a hash.Hash in the New* function, so it's easy to pass that into the cek/civ generators to support other algorithms. Let's do that!
 - Also throw in some consts for other algorithms and make them discoverable
 - Avoid mixing in the recipient key. Instead, try to cast the AEAD cipher to an interface that takes a recipient key and use that. This avoids the dependence on 2048 bit keys.
 - Remove unused consts and simplified URL encoding